### PR TITLE
chore: bumps version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Devtools-UI
 
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/player-ui/devtools-assets/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/player-ui/devtools-assets/tree/main) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+
 Welcome to Devtools-UI, a monorepo containing a collection of assets packages and an assets plugin designed to be leveraged by [Player-UI](https://player-ui.github.io/).
 
 ## Packages

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devtools-ui",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "description": "",
   "repository": {


### PR DESCRIPTION
## Description

Bumping version for first release.


## Change Type

- [ ] `patch`
- [x] `minor`
- [ ] `major`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.2--canary.11.588</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.0.2--canary.11.588
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
