### PR TITLE
feat: set/get expression for evaluation

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@ module(name = "devtools-ui", version = "1.0")
 
 bazel_dep(name = "rules_player")
 
-git_override(module_name = "rules_player", remote = "https://github.com/player-ui/rules_player.git", commit = "56d4319435f0cafe7e6d9b90223e74d3b4dc25ef")
+git_override(module_name = "rules_player", remote = "https://github.com/player-ui/rules_player.git", commit = "e71339c96deeec1f4976fbc04815143ee23d8541")
 
 bazel_dep(name = "aspect_bazel_lib", version = "1.39.0")
 bazel_dep(name = "aspect_rules_js", version = "1.34.1")

--- a/console/src/dsl/index.tsx
+++ b/console/src/dsl/index.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import {
   AssetPropsWithChildren,
   Asset,
-  isTemplateStringInstance,
   BindingTemplateInstance,
+  ExpressionTemplateInstance,
 } from "@player-tools/dsl";
 import type { ConsoleAsset } from "../types";
 
@@ -15,24 +15,15 @@ export const Console = (
   props: Omit<AssetPropsWithChildren<ConsoleAsset>, "binding"> & {
     /** Binding as template string */
     binding: BindingTemplateInstance;
+    /** Expression as template string */
+    exp: ExpressionTemplateInstance;
   }
 ) => {
   const { exp, binding } = props;
 
-  // Extracting the exp value from the props
-  let expValue: ConsoleAsset["exp"];
-
-  if (isTemplateStringInstance(exp)) {
-    expValue = exp.toValue();
-  } else if (Array.isArray(exp)) {
-    expValue = exp.map((e) => (typeof e === "string" ? e : e.toValue()));
-  } else if (exp) {
-    expValue = exp;
-  }
-
   return (
     <Asset type="console">
-      {exp && <property name="exp">{expValue}</property>}
+      {exp && <property name="exp">{exp.toValue()}</property>}
       {binding && <property name="binding">{binding.toValue()}</property>}
     </Asset>
   );

--- a/console/src/transform/index.ts
+++ b/console/src/transform/index.ts
@@ -23,8 +23,14 @@ export const transform: TransformFunction<ConsoleAsset, TransformedConsole> = (
             includeInvalid: true,
             formatted: false,
           }),
-    evaluate() {
+    evaluate(expression: string) {
       if (asset.exp) {
+        // get the referenced expression property holder from the expression
+        const referencedExpression = asset.exp.match(/{{\s*(.*?)\s*}}/);
+        // set the referenced expression property to the new expression
+        // so it is available to the asset.exp
+        referencedExpression &&
+          options.data.model.set([[referencedExpression[1], expression]]);
         options.evaluate(asset.exp);
       }
     },

--- a/console/src/types/index.ts
+++ b/console/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { Asset, Expression } from "@player-ui/types";
+import type { Asset } from "@player-ui/types";
 
 export interface Evaluation {
   /** A unique key for this expression */
@@ -16,7 +16,7 @@ export interface Evaluation {
 
 export interface ConsoleAsset extends Asset<"console"> {
   /** Evaluate expression */
-  exp?: Expression;
+  exp?: string;
   /** History binding */
   binding?: string;
 }
@@ -26,5 +26,5 @@ export interface TransformedConsole extends ConsoleAsset {
   /** A stateful instance of an action */
   history: Evaluation[];
   /** A method to evaluate the expression */
-  evaluate: () => void;
+  evaluate: (expression: string) => void;
 }

--- a/docs/storybook/src/flows/console/basic.tsx
+++ b/docs/storybook/src/flows/console/basic.tsx
@@ -19,7 +19,7 @@ const bindings = makeBindingsForObject(schema);
 
 const view1 = (
   <Console
-    exp={e`publish('evaluate-expression', ${bindings.expression})`}
+    exp={e`beacon('evaluate-expression', ${bindings.expression})`}
     binding={bindings.history}
   />
 );


### PR DESCRIPTION
## Description

Changes the `Console` transformer to set/get the expression for evaluation. The logic relies on the `exp` to determine which data model property to set/get, so the plugin author is free to use any variable name.

No API changes needed.

## Change Type

- [ ] `patch`
- [x] `minor`
- [ ] `major`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.2--canary.12.628</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.0.2--canary.12.628
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
