### PR TITLE
feat: flame-graph

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -32,6 +32,7 @@ copy-to-clipboard/node_modules
 toggle/node_modules
 code-editor/node_modules
 radio-group/node_modules
+flame-graph/node_modules
 
 # Backup files
 _backup

--- a/docs/site/config/navigation.ts
+++ b/docs/site/config/navigation.ts
@@ -85,6 +85,10 @@ const navigation: Navigation = {
               title: 'Radio Group',
               path: '/assets/radio-group',
             },
+            {
+              title: 'Flame Graph',
+              path: '/assets/flame-graph',
+            },
           ]
         },
       ],

--- a/docs/site/pages/assets/flame-graph.mdx
+++ b/docs/site/pages/assets/flame-graph.mdx
@@ -1,0 +1,86 @@
+# @devtools-ui/flame-graph
+
+## Overview
+
+`@devtools-ui/flame-graph` is a component package designed to be leveraged by a [Player-UI assets plugin](https://player-ui.github.io/next/plugins).
+
+It provides a `flame-graph` component for visualizing profiling data.
+
+## Installation
+
+To install `@devtools-ui/flame-graph`, you can use pnpm or yarn:
+
+```sh
+pnpm i @devtools-ui/flame-graph
+```
+
+or
+
+```sh
+yarn add @devtools-ui/flame-graph
+```
+
+## Usage
+
+You can leverage this asset through the `@devtools-ui/plugin`:
+
+```ts
+import { FlameGraph } from "@devtools-ui/plugin";
+
+// and use it to define your Player-UI content:
+myFlow = {
+  id: "my_flow",
+  views: [<FlameGraph binding={b`my_binding`} height={100} width={200} />],
+};
+```
+
+For more information on how to author Player-UI content using DSL, please check our [Player-UI docs](https://player-ui.github.io/next/dsl#tsxjsx-content-authoring-player-dsl).
+
+Or, your can leverage this asset in your own plugin:
+
+```ts
+// TransformPlugin.ts
+import type { Player, PlayerPlugin } from "@player-ui/player";
+import { AssetTransformPlugin } from "@player-ui/asset-transform-plugin";
+import { flameGraphTransform } from "@devtools-ui/flame-graph";
+
+export class TransformsPlugin implements PlayerPlugin {
+  name = "my-plugin-transforms";
+
+  apply(player: Player) {
+    player.registerPlugin(
+      new AssetTransformPlugin([[{ type: "flame-graph" }, flameGraphTransform]])
+    );
+  }
+}
+```
+
+```ts
+// AssetRegistryPlugin.ts
+import React from "react";
+import type { Player } from "@player-ui/player";
+import type {
+  ExtendedPlayerPlugin,
+  ReactPlayer,
+  ReactPlayerPlugin,
+} from "@player-ui/react";
+import { AssetProviderPlugin } from "@player-ui/asset-provider-plugin-react";
+import { TransformsPlugin } from "./TransformPlugin";
+import { FlameGraphAsset, FlameGraphComponent } from "@devtools-ui/flame-graph";
+
+export class AssetsRegistryPlugin
+  implements ReactPlayerPlugin, ExtendedPlayerPlugin<[FlameGraphAsset]>
+{
+  name = "my-plugin";
+
+  applyReact(reactPlayer: ReactPlayer) {
+    reactPlayer.registerPlugin(
+      new AssetProviderPlugin([["flame-graph", FlameGraphComponent]])
+    );
+  }
+
+  apply(player: Player) {
+    player.registerPlugin(new TransformsPlugin());
+  }
+}
+```

--- a/docs/storybook/.storybook/preview.ts
+++ b/docs/storybook/.storybook/preview.ts
@@ -13,6 +13,7 @@ import DevtoolsUIPlugin, {
   Toggle,
   CodeEditor,
   RadioGroup,
+  FlameGraph,
 } from "@devtools-ui/plugin";
 import { Preview } from "@storybook/react";
 import { CommonTypesPlugin } from "@player-ui/common-types-plugin";
@@ -42,6 +43,7 @@ const components = {
   Toggle,
   CodeEditor,
   RadioGroup,
+  FlameGraph,
 };
 
 export const parameters = {

--- a/docs/storybook/src/assets/FlameGraph.mdx
+++ b/docs/storybook/src/assets/FlameGraph.mdx
@@ -1,0 +1,20 @@
+import { Canvas, Meta } from '@storybook/blocks';
+import * as FlameGraphStories from "./FlameGraph.stories";
+
+<Meta of={ FlameGraphStories } />
+
+# FlameGraph Asset
+
+> type: `flame-graph`
+
+It provides a `FlameGraph` component for visualizing profiling data.
+
+## DSL Properties
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `binding` | `string` | true | The binding to the profiling data source (`ProfilerNode`). |
+
+## Basic Use Case
+
+<Canvas of={ FlameGraphStories.Basic } />

--- a/docs/storybook/src/assets/FlameGraph.stories.tsx
+++ b/docs/storybook/src/assets/FlameGraph.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta } from "@storybook/react";
+import { createDSLStory } from "@player-ui/storybook-addon-player";
+import { FlameGraph } from "@devtools-ui/plugin";
+
+const meta: Meta<typeof FlameGraph> = {
+  title: "Devtools UI Assets/FlameGraph",
+  component: FlameGraph,
+};
+
+export default meta;
+
+export const Basic = createDSLStory(
+  () => import("../flows/flame-graph/basic?raw")
+);

--- a/docs/storybook/src/flows/flame-graph/basic.tsx
+++ b/docs/storybook/src/flows/flame-graph/basic.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { FlameGraph } from "@devtools-ui/plugin";
+import type { DSLFlow } from "@player-tools/dsl";
+import { expression as e, makeBindingsForObject } from "@player-tools/dsl";
+import type { Schema } from "@player-ui/types";
+
+const RecordType: Schema.DataType<Record<string, unknown>> = {
+  type: "RecordType",
+};
+
+const schema = {
+  profilerData: RecordType,
+};
+
+const data = makeBindingsForObject(schema);
+
+const view1 = <FlameGraph binding={data.profilerData} />;
+
+const flow: DSLFlow = {
+  id: "flame-graph-basic",
+  views: [view1],
+  data: {
+    profilerData: {
+      name: "root",
+      value: 12,
+      tooltip: "root tooltip",
+      children: [
+        {
+          name: "child1",
+          value: 5,
+          children: [
+            {
+              name: "child1.1",
+              value: 2,
+              tooltip: "child 1.1 tooltip",
+              children: [],
+            },
+            {
+              name: "child1.2",
+              value: 3,
+              tooltip: "child 1.2 tooltip",
+              children: [],
+            },
+          ],
+        },
+        {
+          name: "child2",
+          value: 5,
+          children: [
+            {
+              name: "child2.1",
+              value: 2,
+              tooltip: "child 2.1 tooltip",
+              children: [],
+            },
+            {
+              name: "child2.2",
+              value: 2,
+              tooltip: "child 2.2 tooltip",
+              children: [],
+            },
+            { name: "child2.3", value: 1, children: [] },
+          ],
+        },
+        {
+          name: "child2",
+          value: 2,
+          children: [],
+        },
+      ],
+    },
+  },
+  schema,
+  navigation: {
+    BEGIN: "FLOW_1",
+    FLOW_1: {
+      startState: "VIEW_1",
+      VIEW_1: {
+        state_type: "VIEW",
+        ref: view1,
+        transitions: {
+          "*": "END_Done",
+        },
+      },
+      END_Done: {
+        state_type: "END",
+        outcome: "DONE",
+      },
+    },
+  },
+};
+
+export default flow;

--- a/flame-graph/BUILD
+++ b/flame-graph/BUILD
@@ -1,0 +1,32 @@
+load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@rules_player//javascript:defs.bzl", "js_pipeline")
+load("//helpers:defs.bzl", "tsup_config", "vitest_config")
+
+npm_link_all_packages(name = "node_modules")
+
+tsup_config(name = "tsup_config")
+
+vitest_config(name = "vitest_config")
+
+js_pipeline(
+    package_name = "@devtools-ui/flame-graph",
+    test_deps = [
+        ":node_modules",
+        "//:vitest_config",
+    ],
+    deps = [
+        "//:node_modules/@chakra-ui/react",
+        "//:node_modules/@emotion/react",
+        "//:node_modules/@emotion/styled",
+        "//:node_modules/@player-tools/dsl",
+        "//:node_modules/@player-ui/asset-transform-plugin",
+        "//:node_modules/@player-ui/player",
+        "//:node_modules/@player-ui/react",
+        "//:node_modules/@player-ui/types",
+        "//:node_modules/@types/react",
+        "//:node_modules/dlv",
+        "//:node_modules/framer-motion",
+        "//:node_modules/react",
+        "//:node_modules/react-flame-graph"
+    ],
+)

--- a/flame-graph/README.md
+++ b/flame-graph/README.md
@@ -1,0 +1,86 @@
+# @devtools-ui/flame-graph
+
+## Overview
+
+`@devtools-ui/flame-graph` is a component package designed to be leveraged by a [Player-UI assets plugin](https://player-ui.github.io/next/plugins).
+
+It provides a `flame-graph` component for visualizing profiling data.
+
+## Installation
+
+To install `@devtools-ui/flame-graph`, you can use pnpm or yarn:
+
+```sh
+pnpm i @devtools-ui/flame-graph
+```
+
+or
+
+```sh
+yarn add @devtools-ui/flame-graph
+```
+
+## Usage
+
+You can leverage this asset through the `@devtools-ui/plugin`:
+
+```ts
+import { FlameGraph } from "@devtools-ui/plugin";
+
+// and use it to define your Player-UI content:
+myFlow = {
+  id: "my_flow",
+  views: [<FlameGraph binding={b`my_binding`} height={100} width={200} />],
+};
+```
+
+For more information on how to author Player-UI content using DSL, please check our [Player-UI docs](https://player-ui.github.io/next/dsl#tsxjsx-content-authoring-player-dsl).
+
+Or, your can leverage this asset in your own plugin:
+
+```ts
+// TransformPlugin.ts
+import type { Player, PlayerPlugin } from "@player-ui/player";
+import { AssetTransformPlugin } from "@player-ui/asset-transform-plugin";
+import { flameGraphTransform } from "@devtools-ui/flame-graph";
+
+export class TransformsPlugin implements PlayerPlugin {
+  name = "my-plugin-transforms";
+
+  apply(player: Player) {
+    player.registerPlugin(
+      new AssetTransformPlugin([[{ type: "flame-graph" }, flameGraphTransform]])
+    );
+  }
+}
+```
+
+```ts
+// AssetRegistryPlugin.ts
+import React from "react";
+import type { Player } from "@player-ui/player";
+import type {
+  ExtendedPlayerPlugin,
+  ReactPlayer,
+  ReactPlayerPlugin,
+} from "@player-ui/react";
+import { AssetProviderPlugin } from "@player-ui/asset-provider-plugin-react";
+import { TransformsPlugin } from "./TransformPlugin";
+import { FlameGraphAsset, FlameGraphComponent } from "@devtools-ui/flame-graph";
+
+export class AssetsRegistryPlugin
+  implements ReactPlayerPlugin, ExtendedPlayerPlugin<[FlameGraphAsset]>
+{
+  name = "my-plugin";
+
+  applyReact(reactPlayer: ReactPlayer) {
+    reactPlayer.registerPlugin(
+      new AssetProviderPlugin([["flame-graph", FlameGraphComponent]])
+    );
+  }
+
+  apply(player: Player) {
+    player.registerPlugin(new TransformsPlugin());
+  }
+}
+```

--- a/flame-graph/package.json
+++ b/flame-graph/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@devtools-ui/flame-graph",
+  "version": "0.0.0-PLACEHOLDER",
+  "main": "src/index.ts"
+}

--- a/flame-graph/src/component/index.tsx
+++ b/flame-graph/src/component/index.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { FlameGraph } from "react-flame-graph";
+import { useFlameGraphProps } from "../hooks";
+import type { TransformedFlameGraph } from "../types";
+
+export const FlameGraphComponent = (props: TransformedFlameGraph) => {
+  const transformedProps = useFlameGraphProps(props);
+
+  return <FlameGraph {...transformedProps} />;
+};

--- a/flame-graph/src/dsl/__tests__/index.test.tsx
+++ b/flame-graph/src/dsl/__tests__/index.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { describe, expect, test } from "vitest";
+import { render, binding as b } from "@player-tools/dsl";
+import { FlameGraph } from "../";
+
+describe("DSL: FlameGraph", () => {
+  test("Renders flameGraph", async () => {
+    const rendered = await render(
+      <FlameGraph binding={b`my_binding`} height={100} width={200} />
+    );
+
+    expect(rendered.jsonValue).toStrictEqual({
+      id: "root",
+      type: "flame-graph",
+      binding: "my_binding",
+      height: 100,
+      width: 200,
+    });
+  });
+});

--- a/flame-graph/src/dsl/index.tsx
+++ b/flame-graph/src/dsl/index.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import {
+  AssetPropsWithChildren,
+  Asset,
+  BindingTemplateInstance,
+} from "@player-tools/dsl";
+import type { FlameGraphAsset } from "../types";
+
+/**
+ * Defines the component DSL representation, so users of this plugin can author Player-UI
+ * content leveraging .jsx/.tsx syntax.
+ */
+export const FlameGraph = (
+  props: Omit<AssetPropsWithChildren<FlameGraphAsset>, "binding"> & {
+    /** The binding as a tagged template instance */
+    binding: BindingTemplateInstance;
+  }
+) => {
+  const { children, binding, ...rest } = props;
+
+  return (
+    <Asset type="flame-graph" {...rest}>
+      <property name="binding">{binding.toValue()}</property>
+      {children}
+    </Asset>
+  );
+};

--- a/flame-graph/src/hooks/__tests__/index.test.ts
+++ b/flame-graph/src/hooks/__tests__/index.test.ts
@@ -1,0 +1,67 @@
+import { useFlameGraphProps } from "..";
+import { describe, expect, test } from "vitest";
+import type { ProfilerNode, TransformedFlameGraph } from "../../types";
+
+const data: ProfilerNode = {
+  name: "root",
+  value: 5,
+  tooltip: "tooltip",
+  children: [
+    {
+      name: "child1",
+      value: 5,
+      children: [
+        { name: "child1.1", value: 2, children: [] },
+        { name: "child1.2", value: 3, children: [] },
+      ],
+    },
+    { name: "child2", children: [] },
+  ],
+};
+
+const mockProps: TransformedFlameGraph = {
+  id: "test",
+  type: "flame-graph",
+  data,
+};
+
+describe("useFlameGraphProps", () => {
+  test("transforms data correctly", () => {
+    const result = useFlameGraphProps(mockProps);
+
+    expect(result.data).toStrictEqual({
+      name: "root",
+      value: 5,
+      tooltip: "tooltip",
+      children: [
+        {
+          name: "child1",
+          value: 5,
+          children: [
+            { name: "child1.1", value: 2, children: [] },
+            { name: "child1.2", value: 3, children: [] },
+          ],
+        },
+        { name: "child2", value: 0, children: [] },
+      ],
+    });
+  });
+
+  test("returns default height and width when not provided", () => {
+    const result = useFlameGraphProps(mockProps);
+
+    expect(result.height).toBe(500);
+    expect(result.width).toBe(500);
+  });
+
+  test("returns provided height and width", () => {
+    const result = useFlameGraphProps({
+      ...mockProps,
+      height: 300,
+      width: 300,
+    });
+
+    expect(result.height).toBe(300);
+    expect(result.width).toBe(300);
+  });
+});

--- a/flame-graph/src/hooks/index.ts
+++ b/flame-graph/src/hooks/index.ts
@@ -1,0 +1,20 @@
+import type { Props } from "react-flame-graph";
+import type { TransformedFlameGraph } from "../types";
+
+const transformData = (data: TransformedFlameGraph["data"]): Props["data"] => ({
+  name: data?.name || "root",
+  value: data?.value || 0,
+  ...(data?.tooltip && { tooltip: data.tooltip }),
+  children: data?.children?.map(transformData) || [],
+});
+
+/**
+ * Hook to translate the properties we get from the Player Content (DSL > JSON > transformer)
+ * into what the FlameGraph component expects.
+ */
+export const useFlameGraphProps = (props: TransformedFlameGraph): Props => ({
+  ...props,
+  height: props.height || 500,
+  width: props.width || 500,
+  data: transformData(props.data),
+});

--- a/flame-graph/src/index.ts
+++ b/flame-graph/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export * from "./component";
+export * from "./dsl";
+export * from "./transform";

--- a/flame-graph/src/transform/index.ts
+++ b/flame-graph/src/transform/index.ts
@@ -1,0 +1,21 @@
+import type { TransformFunction } from "@player-ui/player";
+import { FlameGraphAsset, TransformedFlameGraph } from "../types";
+
+/**
+ * Platform-agnostic transform function that takes the properties we get from the Player Content (DSL > JSON)
+ * and embeds Player state and methods:
+ */
+export const flameGraphTransform: TransformFunction<
+  FlameGraphAsset,
+  TransformedFlameGraph
+> = (asset, options) => {
+  return {
+    ...asset,
+    data: asset.binding
+      ? options.data.model.get(asset.binding, {
+          includeInvalid: true,
+          formatted: false,
+        })
+      : undefined,
+  };
+};

--- a/flame-graph/src/types/index.ts
+++ b/flame-graph/src/types/index.ts
@@ -1,0 +1,31 @@
+import type { Asset } from "@player-ui/types";
+
+export type ProfilerNode = {
+  /** hook name */
+  name: string;
+  /* startTime of the hook */
+  startTime?: number;
+  /** endTime of the hook */
+  endTime?: number;
+  /** duration of hook resolution times in ms */
+  value?: number;
+  /** tooltip to be shown on hover */
+  tooltip?: string;
+  /** subhook profiler nodes */
+  children: ProfilerNode[];
+};
+
+export interface FlameGraphAsset extends Asset<"flame-graph"> {
+  /** Dot separated string Representation of a path within the data-model */
+  binding?: string;
+  /** height of the flame graph */
+  height?: number;
+  /** width of the flame graph */
+  width?: number;
+}
+
+/** A stateful instance of the asset */
+export interface TransformedFlameGraph extends FlameGraphAsset {
+  // The result of the transformation (transform/index.ts)
+  data?: ProfilerNode;
+}

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "react-docgen-typescript": "^2.2.2",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.12",
+    "react-flame-graph": "^1.4.0",
     "react-icons": "^5.0.1",
     "react-redux": "^9.1.0",
     "react-syntax-highlighter": "^15.5.0",

--- a/plugin/BUILD
+++ b/plugin/BUILD
@@ -25,6 +25,7 @@ js_pipeline(
         ":node_modules/@devtools-ui/toggle",
         ":node_modules/@devtools-ui/code-editor",
         ":node_modules/@devtools-ui/radio-group",
+        ":node_modules/@devtools-ui/flame-graph",
         "//:node_modules/@chakra-ui/react",
         "//:node_modules/@player-ui/asset-provider-plugin-react",
         "//:node_modules/@player-ui/asset-transform-plugin",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -20,6 +20,7 @@ It register the following assets to your React Player instance:
 - code-editor
 - radio-group
 - toggle
+- flame-graph
 
 ## Installation
 

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -17,6 +17,7 @@
     "@devtools-ui/copy-to-clipboard": "workspace:*",
     "@devtools-ui/code-editor": "workspace:*",
     "@devtools-ui/toggle": "workspace:*",
-    "@devtools-ui/radio-group": "workspace:*"
+    "@devtools-ui/radio-group": "workspace:*",
+    "@devtools-ui/flame-graph": "workspace:*"
   }
 }

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -18,6 +18,7 @@ import {
 } from "@devtools-ui/copy-to-clipboard";
 import { CodeEditorAsset, CodeEditor } from "@devtools-ui/code-editor";
 import { RadioGroupAsset, RadioGroup } from "@devtools-ui/radio-group";
+import { FlameGraphAsset, FlameGraph } from "@devtools-ui/flame-graph";
 import { AssetsRegistryPlugin } from "./plugins";
 
 export default AssetsRegistryPlugin;
@@ -37,6 +38,7 @@ export type {
   ToggleAsset,
   CodeEditorAsset,
   RadioGroupAsset,
+  FlameGraphAsset,
 };
 
 export {
@@ -54,4 +56,5 @@ export {
   Toggle,
   CodeEditor,
   RadioGroup,
+  FlameGraph,
 };

--- a/plugin/src/plugins/AssetsRegistryPlugin.tsx
+++ b/plugin/src/plugins/AssetsRegistryPlugin.tsx
@@ -30,6 +30,7 @@ import { TextAsset, TextComponent } from "@devtools-ui/text";
 import { ToggleAsset, ToggleComponent } from "@devtools-ui/toggle";
 import { CodeEditorAsset, CodeEditorComponent } from "@devtools-ui/code-editor";
 import { RadioGroupAsset, RadioGroupComponent } from "@devtools-ui/radio-group";
+import { FlameGraphAsset, FlameGraphComponent } from "@devtools-ui/flame-graph";
 import { TransformsPlugin } from "./TransformPlugin";
 
 const OptionalChakraThemeProvider = (
@@ -62,7 +63,8 @@ export class AssetsRegistryPlugin
         CopyToClipboardAsset,
         CodeEditorAsset,
         ToggleAsset,
-        RadioGroupAsset
+        RadioGroupAsset,
+        FlameGraphAsset
       ]
     >
 {
@@ -85,6 +87,7 @@ export class AssetsRegistryPlugin
         ["code-editor", CodeEditorComponent],
         ["toggle", ToggleComponent],
         ["radio-group", RadioGroupComponent],
+        ["flame-graph", FlameGraphComponent],
       ])
     );
 

--- a/plugin/src/plugins/TransformPlugin.ts
+++ b/plugin/src/plugins/TransformPlugin.ts
@@ -9,6 +9,7 @@ import { copyToClipboardTransform } from "@devtools-ui/copy-to-clipboard";
 import { toggleTransform } from "@devtools-ui/toggle";
 import { codeEditorTransform } from "@devtools-ui/code-editor";
 import { radioGroupTransform } from "@devtools-ui/radio-group";
+import { flameGraphTransform } from "@devtools-ui/flame-graph";
 
 export class TransformsPlugin implements PlayerPlugin {
   name = "devtools-ui-transforms";
@@ -25,6 +26,7 @@ export class TransformsPlugin implements PlayerPlugin {
         [{ type: "toggle" }, toggleTransform],
         [{ type: "code-editor" }, codeEditorTransform],
         [{ type: "radio-group" }, radioGroupTransform],
+        [{ type: "flame-graph" }, flameGraphTransform],
       ])
     );
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,9 @@ importers:
       react-error-boundary:
         specifier: ^4.0.12
         version: 4.0.13(react@18.3.1)
+      react-flame-graph:
+        specifier: ^1.4.0
+        version: 1.4.0(react-dom@18.3.1)(react@18.3.1)
       react-icons:
         specifier: ^5.0.1
         version: 5.2.0(react@18.3.1)
@@ -363,6 +366,15 @@ importers:
         specifier: workspace:*
         version: link:../../addon-storybook
 
+  flame-graph:
+    dependencies:
+      '@devtools-ui/collection':
+        specifier: workspace:*
+        version: link:../collection
+      '@devtools-ui/text':
+        specifier: workspace:*
+        version: link:../text
+
   input:
     dependencies:
       '@devtools-ui/text':
@@ -413,6 +425,9 @@ importers:
       '@devtools-ui/copy-to-clipboard':
         specifier: workspace:*
         version: link:../copy-to-clipboard
+      '@devtools-ui/flame-graph':
+        specifier: workspace:*
+        version: link:../flame-graph
       '@devtools-ui/input':
         specifier: workspace:*
         version: link:../input
@@ -9215,6 +9230,12 @@ packages:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==, tarball: https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz}
     dev: false
 
+  /flow-bin@0.118.0:
+    resolution: {integrity: sha512-jlbUu0XkbpXeXhan5xyTqVK1jmEKNxE8hpzznI3TThHTr76GiFwK0iRzhDo4KNy+S9h/KxHaqVhTP86vA6wHCg==, tarball: https://registry.npmjs.org/flow-bin/-/flow-bin-0.118.0.tgz}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+    dev: false
+
   /flow-parser@0.235.1:
     resolution: {integrity: sha512-s04193L4JE+ntEcQXbD6jxRRlyj9QXcgEl2W6xSjH4l9x4b0eHoCHfbYHjqf9LdZFUiM5LhgpiqsvLj/AyOyYQ==, tarball: https://registry.npmjs.org/flow-parser/-/flow-parser-0.235.1.tgz}
     engines: {node: '>=0.4.0'}
@@ -11300,6 +11321,10 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /memoize-one@3.1.1:
+    resolution: {integrity: sha512-YqVh744GsMlZu6xkhGslPSqSurOv6P+kLN2J3ysBZfagLcL5FdRK/0UpgLoL8hwjjEvvAVkjJZyFP+1T6p1vgA==, tarball: https://registry.npmjs.org/memoize-one/-/memoize-one-3.1.1.tgz}
+    dev: false
+
   /memoizerific@1.11.3:
     resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==, tarball: https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz}
     dependencies:
@@ -12988,6 +13013,20 @@ packages:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==, tarball: https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz}
     dev: false
 
+  /react-flame-graph@1.4.0(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-DaCK9ZX+xK0mNca72kUE5cu6T8hGe/KLsefQWf+eT9sVt+0WP1dVxZCGD8Svfn2KrZB9Mv011Intg/yG2YWSxA==, tarball: https://registry.npmjs.org/react-flame-graph/-/react-flame-graph-1.4.0.tgz}
+    engines: {node: '>8.0.0'}
+    peerDependencies:
+      react: ^18.2.0
+      react-dom: ^18.2.0
+    dependencies:
+      flow-bin: 0.118.0
+      memoize-one: 3.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-window: 1.8.10(react-dom@18.3.1)(react@18.3.1)
+    dev: false
+
   /react-flatten-children@1.1.2:
     resolution: {integrity: sha512-9pnG/uw2Wa0n97s+yBZg/WgfMPE8RC4qNcr6iYbyb19sacCk3gRJCmCzAhTuANSWesFsK9v/yTKW42pkenaAfw==, tarball: https://registry.npmjs.org/react-flatten-children/-/react-flatten-children-1.1.2.tgz}
     dev: false
@@ -13151,6 +13190,19 @@ packages:
       prismjs: 1.29.0
       react: 18.3.1
       refractor: 3.6.0
+    dev: false
+
+  /react-window@1.8.10(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==, tarball: https://registry.npmjs.org/react-window/-/react-window-1.8.10.tgz}
+    engines: {node: '>8.0.0'}
+    peerDependencies:
+      react: ^18.2.0
+      react-dom: ^18.2.0
+    dependencies:
+      '@babel/runtime': 7.24.5
+      memoize-one: 3.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     dev: false
 
   /react@18.3.1:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,3 +17,4 @@ packages:
   - "toggle"
   - "code-editor"
   - "radio-group"
+  - "flame-graph"

--- a/typings/react-flame-graph.d.ts
+++ b/typings/react-flame-graph.d.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare module "react-flame-graph" {
+  export type ChartNode = {
+    name: string;
+    value: number;
+    children: ChartNode[];
+    backgroundColor?: string;
+    color?: string;
+    tooltip?: string;
+  };
+
+  export type Props = {
+    data: ChartData;
+    disableDefaultTooltips?: boolean;
+    height: number;
+    width: number;
+    onChange?: (chartNode: ChartNode, uid: any) => void;
+    onMouseMove?: (event: React.MouseEvent, node: RawData) => void;
+    onMouseOut?: (event: React.MouseEvent, node: RawData) => void;
+    onMouseOver?: (event: React.MouseEvent, node: RawData) => void;
+  };
+
+  export function FlameGraph(props: Props): JSX.Element;
+}


### PR DESCRIPTION
### Description

Adds `flame-graph` component.

### Screenshot

![Screenshot 2024-05-13 at 3 39 39 PM](https://github.com/player-ui/devtools-assets/assets/26394217/2847184e-8fb6-4580-ae72-a2963df5d7cc)

### Change Type 

- [ ] `patch`
- [x] `minor`
- [ ] `major`

# Release Notes

Adds `flame-graph` component.

```ts
<FlameGraph binding={b`my_binding`} height={100} width={200} />
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.0--canary.25.1169</code></summary>
  <br />

  Try this version out locally by upgrading relevant packages to 0.2.0--canary.25.1169
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
